### PR TITLE
Revert "fix: correctly handle contract without storage items"

### DIFF
--- a/crates/gateway-types/src/class_hash.rs
+++ b/crates/gateway-types/src/class_hash.rs
@@ -151,9 +151,8 @@ pub mod from_parts {
     }
 }
 
-pub fn compute_cairo_hinted_class_hash(
-    contract_definition: &json::CairoContractDefinition<'_>,
-) -> Result<Felt> {
+
+pub fn compute_cairo_hinted_class_hash(contract_definition: &json::CairoContractDefinition) -> Result<Felt> {
     use std::io::Write;
 
     // It's less efficient than tweaking the formatter to emit the encoding but I
@@ -180,21 +179,18 @@ pub fn compute_cairo_hinted_class_hash(
     Ok(truncated_keccak(<[u8; 32]>::from(hash.finalize())))
 }
 
-/// Prepares the JSON contract definition for hash calculation by removing
-/// unnecessary fields and ensuring consistency in formatting.
+/// Prepares the JSON contract definition for hash calculation by removing unnecessary fields and
+/// ensuring consistency in formatting.
 ///
-/// This function modifies the input `contract_definition` to ensure it is in a
-/// suitable state for calculating the class hash. It removes the `debug_info`
-/// field, checks and removes "accessible_scopes" and "flow_tracking_data"
-/// fields if they are empty or null, and applies a backwards compatibility hack
-/// for missing `compiler_version` by adding extra space to named tuple type
-/// definitions.
+/// This function modifies the input `contract_definition` to ensure it is in a suitable state for
+/// calculating the class hash. It removes the `debug_info` field, checks and removes "accessible_scopes"
+/// and "flow_tracking_data" fields if they are empty or null, and applies a backwards compatibility
+/// hack for missing `compiler_version` by adding extra space to named tuple type definitions.
 ///
 /// # Errors
 ///
-/// This function returns an error if it fails to modify the contract
-/// definition, such as when an attribute is not an object or when
-/// "accessible_scopes" is not an array type.
+/// This function returns an error if it fails to modify the contract definition, such as when an
+/// attribute is not an object or when "accessible_scopes" is not an array type.
 pub fn prepare_json_contract_definition(
     contract_definition: &mut json::CairoContractDefinition<'_>,
 ) -> Result<(), anyhow::Error> {

--- a/crates/merkle-tree/src/class.rs
+++ b/crates/merkle-tree/src/class.rs
@@ -1,4 +1,6 @@
 use anyhow::Context;
+use bitvec::order::Msb0;
+use bitvec::prelude::BitSlice;
 use pathfinder_common::hash::PoseidonHash;
 use pathfinder_common::trie::TrieNode;
 use pathfinder_common::{

--- a/crates/merkle-tree/src/contract.rs
+++ b/crates/merkle-tree/src/contract.rs
@@ -83,8 +83,15 @@ impl<'tx> ContractsStorageTree<'tx> {
         contract: ContractAddress,
         block: BlockNumber,
         key: &BitSlice<u8, Msb0>,
-        root: u64,
     ) -> anyhow::Result<Option<Vec<TrieNode>>> {
+        let root = tx
+            .contract_root_index(block, contract)
+            .context("Querying contract root index")?;
+
+        let Some(root) = root else {
+            return Ok(None);
+        };
+
         let storage = ContractStorage {
             tx,
             block: Some(block),

--- a/crates/rpc/src/pathfinder/methods/get_proof.rs
+++ b/crates/rpc/src/pathfinder/methods/get_proof.rs
@@ -256,11 +256,7 @@ pub async fn get_proof(
             .contract_state_hash(header.number, input.contract_address)
             .context("Fetching contract's state hash")?;
 
-        let root = tx
-            .contract_root_index(header.number, input.contract_address)
-            .context("Querying contract root index")?;
-
-        if contract_state_hash.is_none() || root.is_none() {
+        if contract_state_hash.is_none() {
             return Ok(GetProofOutput {
                 state_commitment,
                 class_commitment,
@@ -291,7 +287,6 @@ pub async fn get_proof(
                 input.contract_address,
                 header.number,
                 k.view_bits(),
-                root.expect("Root cannot be empty"),
             )
             .context("Get proof from contract state tree")?
             .ok_or_else(|| {


### PR DESCRIPTION
Problem:
The PR #3 adds a fix to handle when a contract storage has no root. The fix does an early return with:
```rs
fn get_proof() { 
           // <snip>
     if root.is_none() {
            return Ok(GetProofOutput {
                state_commitment,
                class_commitment,
                contract_proof,
                contract_data: None,
            });
    }
}
```
This is undesirable since some contracts might not have a storage root but might still have `contract_data` meaning our the fix is buggy and needs to be reworked.

Reverts Moonsong-Labs/pathfinder#3