### PR TITLE
fix: correctly handle `get_proof` for contract without a root index

### DIFF
--- a/crates/merkle-tree/src/contract.rs
+++ b/crates/merkle-tree/src/contract.rs
@@ -83,15 +83,8 @@ impl<'tx> ContractsStorageTree<'tx> {
         contract: ContractAddress,
         block: BlockNumber,
         key: &BitSlice<u8, Msb0>,
+        root: u64,
     ) -> anyhow::Result<Option<Vec<TrieNode>>> {
-        let root = tx
-            .contract_root_index(block, contract)
-            .context("Querying contract root index")?;
-
-        let Some(root) = root else {
-            return Ok(None);
-        };
-
         let storage = ContractStorage {
             tx,
             block: Some(block),


### PR DESCRIPTION
## In a nutshell

Key changes include:
- Adjusting the get_proof method to return an empty list when no contract root is found.
- Adding checks for None values when retrieving contract roots.

## Problem: 
Pathfinder returns an internal error when one tries to fetch a proof for contract with a `contract_state_hash` but without a `root_index` for the current block height. Pathfinder returns none which is propagated down to an internal error.

## Replication
The following is an example of a request that fails without this fix:
```json
{
  "id": "0",
  "jsonrpc": "2.0",
  "method": "pathfinder_getProof",
  "params": {
    "block_id": {
      "block_number": 155006
    },
    "contract_address": "0x40a29e36c82f868dc2b5712bc6729c6132ca75ae46d6c75718ecbd49a0c9fb7",
    "keys": [
      "0x206f38f7e4f15e87567361213c28f235cccdaa1d7fd34c9db1dfe9489c6a091"
    ]
  }
}
```

## Solution: 
When there is no root_index, this fix will return empty `ProofNodes` ie `ProofNodes(vec![])` for each of the keys.

## Extras
This fix also prevents multiple calls to the database fetching the same root (same contract and block number) while looping through the keys.

